### PR TITLE
Add missing response in Figure EDHOC and OSCORE run sequentially

### DIFF
--- a/draft-ietf-core-oscore-edhoc.md
+++ b/draft-ietf-core-oscore-edhoc.md
@@ -146,8 +146,16 @@ EDHOC verification                                           |
         |                                                    |
         |                                           EDHOC verification
         |                                                    +
-OSCORE Sec Ctx                                        OSCORE Sec Ctx
-  Derivation                                            Derivation
+        |                                             OSCORE Sec Ctx
+        |                                               Derivation
+        |                                                    |
+        | <---------------- EDHOC Response------------------ |
+        |       Header: 2.04 (Changed)                       |
+        |       Content-Format: application/edhoc+cbor-seq   |
+        |       Payload: EDHOC message_4                     |
+        |                                                    |
+OSCORE Sec Ctx                                               |
+  Derivation                                                 |
         |                                                    |
         | ---------------- OSCORE Request -----------------> |
         |   Header: 0.02 (POST)                              |


### PR DESCRIPTION
Hi,

I just noticed that in figure 1, the response to the second CoAP POST is missing.

Regards,
Signed-off-by: David Navarro <david.navarro@ioterop.com>
